### PR TITLE
OSV-3052| CVE-2025-46762 - Bump org.apache.parquet:parquet-avro from 1.15.1 to 1.15.2 in /extens…

### DIFF
--- a/extensions-core/parquet-extensions/pom.xml
+++ b/extensions-core/parquet-extensions/pom.xml
@@ -33,7 +33,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <properties>
-    <parquet.version>1.13.1</parquet.version>
+    <parquet.version>1.15.2</parquet.version>
   </properties>
   <dependencies>
     <dependency>
@@ -204,9 +204,6 @@
           <scope>runtime</scope>
         </dependency>
       </dependencies>
-      <properties>
-        <parquet.version>1.13.0</parquet.version>
-      </properties>
     </profile>
   </profiles>
 </project>

--- a/extensions-core/parquet-extensions/src/main/java/org/apache/parquet/avro/DruidParquetAvroReadSupport.java
+++ b/extensions-core/parquet-extensions/src/main/java/org/apache/parquet/avro/DruidParquetAvroReadSupport.java
@@ -125,6 +125,6 @@ public class DruidParquetAvroReadSupport extends AvroReadSupport<GenericRecord>
         AvroDataSupplier.class
     );
     AvroDataSupplier supplier = ReflectionUtils.newInstance(suppClass, configuration);
-    return new AvroRecordMaterializer<>(parquetSchema, avroSchema, supplier.get());
+    return new AvroRecordMaterializer<>(parquetSchema, avroSchema, supplier.get(), new ReflectClassValidator.PackageValidator());
   }
 }

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -3165,7 +3165,7 @@ name: Apache Parquet
 license_category: binary
 module: extensions/druid-parquet-extensions
 license_name: Apache License version 2.0
-version: 1.13.0
+version: 1.15.2
 libraries:
   - org.apache.parquet: parquet-avro
   - org.apache.parquet: parquet-column


### PR DESCRIPTION
…ions-core/parquet-extensions (#18131)

* Bump org.apache.parquet:parquet-avro

Bumps [org.apache.parquet:parquet-avro](https://github.com/apache/parquet-mr) from 1.15.1 to 1.15.2.
- [Release notes](https://github.com/apache/parquet-mr/releases)
- [Changelog](https://github.com/apache/parquet-java/blob/master/CHANGES.md)
- [Commits](https://github.com/apache/parquet-mr/compare/apache-parquet-1.15.1...apache-parquet-1.15.2)

---
updated-dependencies:
- dependency-name: org.apache.parquet:parquet-avro dependency-version: 1.15.2 dependency-type: direct:production ...



* remove second parquet.version

* fix

* bump.licenses.yaml


