### PR TITLE
[CVE-Fix]: Update netty4 version (#17755)

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -1247,7 +1247,7 @@ name: Netty
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 4.1.100.Final
+version: 4.1.118.Final
 libraries:
   - io.netty: netty-buffer
   - io.netty: netty-codec
@@ -4378,7 +4378,7 @@ name: Netty
 license_category: binary
 module: extensions/druid-azure-extensions
 license_name: Apache License version 2.0
-version: 2.0.61.Final
+version: 2.0.70.Final
 libraries:
   - io.netty: netty-tcnative-boringssl-static
   - io.netty: netty-tcnative-classes

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <mysql.version>5.1.49</mysql.version>
         <mariadb.version>2.7.3</mariadb.version>
         <netty3.version>3.10.6.Final</netty3.version>
-        <netty4.version>4.1.100.Final</netty4.version>
+        <netty4.version>4.1.118.Final</netty4.version>
         <postgresql.version>42.7.2</postgresql.version>
         <protobuf.version>3.25.5</protobuf.version>
         <resilience4j.version>1.3.1</resilience4j.version>


### PR DESCRIPTION
This PR updates the netty4 version used to resolve CVE-2025-25193: https://nvd.nist.gov/vuln/detail/CVE-2025-25193

