### PR TITLE
OSV-18048 - CVE - Increasing log4j2 version to fix the Druid log4j CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <jackson.version>2.12.7</jackson.version>
         <jackson.core.version>${jackson.version}</jackson.core.version>
         <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
-        <log4j.version>2.25.3</log4j.version>
+        <log4j.version>2.25.4</log4j.version>
         <mysql.version>5.1.49</mysql.version>
         <mariadb.version>2.7.3</mariadb.version>
         <netty3.version>3.10.6.Final</netty3.version>


### PR DESCRIPTION
- Library : log4j
- Version : -> 2.25.4
- Tickets : OSV-18048, OSV-17954, OSV-17953, OSV-17952, OSV-17951, OSV-17950

Per-library Phase 1 fix for the Druid 3.2.3.6 CVEs (build-validated on JDK 8 via -Pdist).