### PR TITLE
OSV-18042 - CVE - Increasing netty version to fix the Druid netty CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <mysql.version>5.1.49</mysql.version>
         <mariadb.version>2.7.3</mariadb.version>
         <netty3.version>3.10.6.Final</netty3.version>
-        <netty4.version>4.1.132.Final</netty4.version>
+        <netty4.version>4.1.135.Final</netty4.version>
         <postgresql.version>42.7.2</postgresql.version>
         <protobuf.version>3.25.5</protobuf.version>
         <resilience4j.version>1.3.1</resilience4j.version>


### PR DESCRIPTION
- Library : netty
- Version : -> 4.1.135.Final
- Tickets : OSV-18042, OSV-18040, OSV-18039, OSV-18038, OSV-18037, OSV-18036, OSV-18035, OSV-18011, OSV-17941

Per-library Phase 1 fix for the Druid 3.2.3.6 CVEs (build-validated on JDK 8 via -Pdist).