### PR TITLE
OSV-18043 - CVE - Increasing postgresql version to fix the Druid postgresql CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <mariadb.version>2.7.3</mariadb.version>
         <netty3.version>3.10.6.Final</netty3.version>
         <netty4.version>4.1.132.Final</netty4.version>
-        <postgresql.version>42.7.2</postgresql.version>
+        <postgresql.version>42.7.11</postgresql.version>
         <protobuf.version>3.25.5</protobuf.version>
         <resilience4j.version>1.3.1</resilience4j.version>
         <slf4j.version>1.7.36</slf4j.version>


### PR DESCRIPTION
- Library : postgresql
- Version : -> 42.7.11
- Tickets : OSV-18043

Per-library Phase 1 fix for the Druid 3.2.3.6 CVEs (build-validated on JDK 8 via -Pdist).