### PR TITLE
OSV-18024 - CVE - Increasing json-path version to fix the Druid json-path CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -965,7 +965,7 @@
             <dependency>
                 <groupId>com.jayway.jsonpath</groupId>
                 <artifactId>json-path</artifactId>
-                <version>2.3.0</version>
+                <version>2.9.0</version>
             </dependency>
             <dependency>
                 <groupId>net.thisptr</groupId>


### PR DESCRIPTION
- Library : json-path
- Version : -> 2.9.0
- Tickets : OSV-18024

Per-library Phase 1 fix for the Druid 3.2.3.6 CVEs (build-validated on JDK 8 via -Pdist).