### PR TITLE
OSV-17937 - CVE - Pinning jackson-databind to 2.12.7.1 to fix the Druid jackson-databind CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -617,6 +617,11 @@
                 <version>1.5.2-3</version>
             </dependency>
             <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>2.12.7.1</version>
+            </dependency>
+            <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
                 <version>${jackson.core.version}</version>


### PR DESCRIPTION
- Tickets : OSV-17937, OSV-17936

Druid 3.2.3.6 CVE Phase 2 per-library fix; build-validated on JDK 8 via -Pdist and verified in the distribution.