### PR TITLE
OSV-17957 - CVE - Increasing jose4j version to 0.9.6 to fix the Druid jose4j CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -424,7 +424,7 @@
             <dependency>
                 <groupId>org.bitbucket.b_c</groupId>
                 <artifactId>jose4j</artifactId>
-                <version>0.9.4</version>
+                <version>0.9.6</version>
             </dependency>
             <!-- transitive dependency of kafka-clientorg.apache.calcite:calcite-testkit
             and kafka-protobuf-provider


### PR DESCRIPTION
- Tickets : OSV-17957

Druid 3.2.3.6 CVE Phase 2 per-library fix; build-validated on JDK 8 via -Pdist and verified in the distribution.