### PR TITLE
OSV-18047 - CVE - Increasing plexus-utils version to 3.6.1 to fix the Druid plexus-utils CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1046,7 +1046,7 @@
             <dependency>
                 <groupId>org.codehaus.plexus</groupId>
                 <artifactId>plexus-utils</artifactId>
-                <version>3.0.24</version>
+                <version>3.6.1</version>
             </dependency>
             <dependency>
                 <groupId>com.github.ben-manes.caffeine</groupId>


### PR DESCRIPTION
- Tickets : OSV-18047

Druid 3.2.3.6 CVE Phase 2 per-library fix; build-validated on JDK 8 via -Pdist and verified in the distribution.