### PR TITLE
OSV-18025 - CVE - Increasing aircompressor version to 2.0.3 to fix the Druid aircompressor CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -617,6 +617,11 @@
                 <version>1.5.2-3</version>
             </dependency>
             <dependency>
+                <groupId>io.airlift</groupId>
+                <artifactId>aircompressor</artifactId>
+                <version>2.0.3</version>
+            </dependency>
+            <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
                 <version>${jackson.core.version}</version>


### PR DESCRIPTION
- Tickets : OSV-18025, OSV-17955

Druid 3.2.3.6 CVE Phase 2 per-library fix; build-validated on JDK 8 via -Pdist and verified in the distribution.