### PR TITLE
OSV-17940 - CVE - Increasing azure-sdk-bom to 1.2.25 (azure-identity 1.13.0) to fix the Druid azure-identity CVEs

### DIFF
--- a/extensions-core/azure-extensions/pom.xml
+++ b/extensions-core/azure-extensions/pom.xml
@@ -38,7 +38,7 @@
             <dependency>
                 <groupId>com.azure</groupId>
                 <artifactId>azure-sdk-bom</artifactId>
-                <version>1.2.19</version>
+                <version>1.2.25</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
- Tickets : OSV-17940

Druid 3.2.3.6 CVE Phase 2 per-library fix; build-validated on JDK 8 via -Pdist and verified in the distribution.