### PR TITLE
OSV-17943 - CVE - Pinning woodstox-core to 6.5.1 to fix the Druid woodstox-core CVEs

### DIFF
--- a/extensions-core/azure-extensions/pom.xml
+++ b/extensions-core/azure-extensions/pom.xml
@@ -36,6 +36,11 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>com.fasterxml.woodstox</groupId>
+                <artifactId>woodstox-core</artifactId>
+                <version>6.5.1</version>
+            </dependency>
+            <dependency>
                 <groupId>com.azure</groupId>
                 <artifactId>azure-sdk-bom</artifactId>
                 <version>1.2.19</version>


### PR DESCRIPTION
- Tickets : OSV-17943

Druid 3.2.3.6 CVE Phase 2 per-library fix; build-validated on JDK 8 via -Pdist and verified in the distribution.