### PR TITLE
OSV-21543: Bump netty to 4.1.135.Final (netty 4.1.1* CVEs)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <mysql.version>5.1.49</mysql.version>
         <mariadb.version>2.7.3</mariadb.version>
         <netty3.version>3.10.6.Final</netty3.version>
-        <netty4.version>4.1.132.Final</netty4.version>
+        <netty4.version>4.1.135.Final</netty4.version>
         <postgresql.version>42.7.11</postgresql.version>
         <protobuf.version>3.25.5</protobuf.version>
         <resilience4j.version>1.3.1</resilience4j.version>


### PR DESCRIPTION
## Summary
- Bump Netty to **4.1.135.Final** to address CVEs reported against netty **4.1.1\*.Final**.

## Tickets (24)
OSV-21543, OSV-21544, OSV-21550, OSV-21551, OSV-21558, OSV-21561, OSV-21564, OSV-21567, OSV-21588, OSV-21589, OSV-21590, OSV-21591, OSV-21592, OSV-21593, OSV-21603, OSV-21604, OSV-21605, OSV-21606, OSV-21607, OSV-21608, OSV-21609, OSV-21610, OSV-21611, OSV-21612
