### PR TITLE
OSV-21534 - CVE - Bumped-up Jackson to 2.18.6 to address GHSA-72hv-8253-57qq

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,8 +113,8 @@
         <hamcrest.version>1.3</hamcrest.version>
         <jetty.version>9.4.56.v20240826</jetty.version>
         <jersey.version>1.19.4</jersey.version>
-        <jackson.core.version>2.18.4.1</jackson.core.version>
-        <jackson.version>2.18.4</jackson.version>
+        <jackson.core.version>2.18.6</jackson.core.version>
+        <jackson.version>2.18.6</jackson.version>
         <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
         <log4j.version>2.18.0</log4j.version>
         <mysql.version>5.1.49</mysql.version>


### PR DESCRIPTION
- Library : Jackson
- Version : -> 2.18.6
- Tickets : OSV-21534, OSV-21542, OSV-21614