### PR TITLE
OSV-21548 - CVE - Bumped-up Log4j to 2.25.4 to address CVE-2026-34479

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
         <jackson.core.version>2.18.4.1</jackson.core.version>
         <jackson.version>2.18.4</jackson.version>
         <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
-        <log4j.version>2.18.0</log4j.version>
+        <log4j.version>2.25.4</log4j.version>
         <mysql.version>5.1.49</mysql.version>
         <mariadb.version>2.7.3</mariadb.version>
         <netty3.version>3.10.6.Final</netty3.version>


### PR DESCRIPTION
- Library : Log4j
- Version : -> 2.25.4
- Tickets : OSV-21548, OSV-21581, OSV-21582, OSV-21583, OSV-21584, OSV-21585