### PR TITLE
OSV-21569 - CVE - Bumped-up Jetty to 9.4.57.v20241219 to address CVE-2024-13009/CVE-2024-6763

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <guava.version>32.0.1-jre</guava.version>
         <guice.version>4.1.0</guice.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <jetty.version>9.4.56.v20240826</jetty.version>
+        <jetty.version>9.4.57.v20241219</jetty.version>
         <jersey.version>1.19.4</jersey.version>
         <jackson.core.version>2.18.4.1</jackson.core.version>
         <jackson.version>2.18.4</jackson.version>


### PR DESCRIPTION
- Component: druid (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: Jetty → 9.4.57.v20241219
- Tickets: OSV-21569, OSV-21570
- Files: pom.xml:jetty.version