### PR TITLE
OSV-21527 - CVE - Bumped-up BouncyCastle to 1.84 to address CVE-2024-29857/CVE-2024-30171/CVE-2024-30172/CVE-2024-34447/CVE-2025-8885/CVE-2025-8916/CVE-2026-0636/CVE-2026-5588/CVE-2026-5598

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -609,6 +609,16 @@
                 <version>1.5.2-3</version>
             </dependency>
             <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcprov-jdk18on</artifactId>
+                <version>1.84</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcpkix-jdk18on</artifactId>
+                <version>1.84</version>
+            </dependency>
+            <dependency>
                 <groupId>io.airlift</groupId>
                 <artifactId>aircompressor</artifactId>
                 <version>2.0.3</version>


### PR DESCRIPTION
- Component: druid (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: BouncyCastle → 1.84
- Tickets: OSV-21527, OSV-21528, OSV-21574, OSV-21575, OSV-21576, OSV-21577, OSV-21578, OSV-21579, OSV-21580
- Files: pom.xml:bouncycastle