### PR TITLE
OSV-21536 - CVE - Bumped-up commons-lang3 to 3.18.0 to address CVE-2025-48924

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -349,7 +349,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.12.0</version>
+                <version>3.18.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
- Component: druid (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: commons-lang3 → 3.18.0
- Tickets: OSV-21536
- Files: pom.xml:commons-lang3