### PR TITLE
OSV-21562 - CVE - Bumped-up commons-compress to 1.26.0 to address CVE-2024-25710/CVE-2024-26308

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -596,7 +596,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
-                <version>1.24.0</version>
+                <version>1.26.0</version>
             </dependency>
             <dependency>
                 <groupId>org.tukaani</groupId>


### PR DESCRIPTION
- Component: druid (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: commons-compress → 1.26.0
- Tickets: OSV-21562, OSV-21563
- Files: pom.xml:commons-compress