### PR TITLE
OSV-21559 - CVE - Bumped-up async-http-client to 3.0.10 to address CVE-2026-40490/CVE-2026-45300

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -987,7 +987,7 @@
             <dependency>
                 <groupId>org.asynchttpclient</groupId>
                 <artifactId>async-http-client</artifactId>
-                <version>3.0.1</version>
+                <version>3.0.10</version>
             </dependency>
             <dependency>
                 <groupId>net.java.dev.jna</groupId>


### PR DESCRIPTION
- Component: druid (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: async-http-client → 3.0.10
- Tickets: OSV-21559, OSV-21560
- Files: pom.xml:async-http-client