### PR TITLE
OSV-21566 - CVE - Bumped-up plexus-utils to 3.6.1 to address CVE-2025-67030

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1037,7 +1037,7 @@
             <dependency>
                 <groupId>org.codehaus.plexus</groupId>
                 <artifactId>plexus-utils</artifactId>
-                <version>3.0.24</version>
+                <version>3.6.1</version>
             </dependency>
             <dependency>
                 <groupId>com.github.ben-manes.caffeine</groupId>


### PR DESCRIPTION
- Component: druid (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: plexus-utils → 3.6.1
- Tickets: OSV-21566
- Files: pom.xml:plexus-utils