### PR TITLE
OSV-21549 - CVE - Bumped-up Rhino to 1.7.15.1 to address CVE-2025-66453

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -591,7 +591,7 @@
             <dependency>
                 <groupId>org.mozilla</groupId>
                 <artifactId>rhino</artifactId>
-                <version>1.7.14</version>
+                <version>1.7.15.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
- Component: druid (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: Rhino → 1.7.15.1
- Tickets: OSV-21549
- Files: pom.xml:rhino