### PR TITLE
OSV-21535 - CVE - Bumped-up azure-sdk-bom/azure-identity to 1.2.25 to address CVE-2024-35255

### DIFF
--- a/extensions-core/azure-extensions/pom.xml
+++ b/extensions-core/azure-extensions/pom.xml
@@ -53,7 +53,7 @@
             <dependency>
                 <groupId>com.azure</groupId>
                 <artifactId>azure-sdk-bom</artifactId>
-                <version>1.2.19</version>
+                <version>1.2.25</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
- Component: druid (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: azure-sdk-bom/azure-identity → 1.2.25
- Tickets: OSV-21535
- Files: extensions-core/azure-extensions/pom.xml:azure-sdk-bom