### PR TITLE
OSV-21615 - CVE - Bumped-up aircompressor to 2.0.3 to address CVE-2025-67721

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -609,6 +609,11 @@
                 <version>1.5.2-3</version>
             </dependency>
             <dependency>
+                <groupId>io.airlift</groupId>
+                <artifactId>aircompressor</artifactId>
+                <version>2.0.3</version>
+            </dependency>
+            <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
                 <version>${jackson.core.version}</version>


### PR DESCRIPTION
- Component: druid (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: aircompressor → 2.0.3
- Tickets: OSV-21615
- Files: pom.xml:aircompressor